### PR TITLE
Fixed a bug with excessive tabs and -vmargs in ubuntu_bb function

### DIFF
--- a/xmind-installer.sh
+++ b/xmind-installer.sh
@@ -76,12 +76,11 @@ cnfg(){
 }
 
 ubuntu_bb(){
-	cat << EOF >> $BIN_DIR/XMind.ini
-	-vmargs
-	--add-modules=java.se.ee
-	-Dosgi.requiredJavaVersion=1.8
-	-Xms256m
-	-Xmx1024m
+cat << EOF >> $BIN_DIR/XMind.ini
+--add-modules=java.se.ee
+-Dosgi.requiredJavaVersion=1.8
+-Xms256m
+-Xmx1024m
 EOF
 }
 


### PR DESCRIPTION
It was appending arguments to XMind.ini file with tabulation before each of them, which caused a startup error, also there was a duplication of arguments -vmargs, it also caused error if not eliminated.
My OS: Kubuntu 18.04
XMind version:  xmind-8-update7-linux
Now it starts properly